### PR TITLE
Update negotiator and fix setting vary header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 0.10
+  - 0.12
+  - "iojs"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var Negotiator = require("negotiator")
-
-var varySplitter = / *, */
+var vary = require("vary");
 
 module.exports = MediaTypes
 
@@ -18,22 +17,9 @@ function MediaTypes(object) {
         var mediaType = neg.mediaType(types)
 
         var handler = object[mediaType] || $default || defaultHandler
-        vary(req, res, "Accept")
+        vary(res, "Accept")
 
         return handler.apply(this, arguments)
-    }
-}
-
-function vary(req, res, header) {
-    var varyHeader = res.getHeader(header)
-    if (varyHeader) {
-        var parts = varyHeader.split(varySplitter)
-        if (parts.indexOf(header) === -1) {
-            parts.push(header)
-        }
-        res.setHeader(header, parts.join(", "))
-    } else {
-        res.setHeader(header, "Accept")
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function MediaTypes(object) {
 
     function requestHandler(req, res) {
         var neg = new Negotiator(req)
-        var mediaType = neg.preferredMediaType(types)
+        var mediaType = neg.mediaType(types)
 
         var handler = object[mediaType] || $default || defaultHandler
         vary(req, res, "Accept")

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "negotiator": "~0.2.5"
+    "negotiator": "^0.5.3"
   },
   "devDependencies": {
     "tape": "~2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "negotiator": "^0.5.3"
+    "negotiator": "^0.5.3",
+    "vary": "^1.0.0"
   },
   "devDependencies": {
     "tape": "~2.3.0",

--- a/test/integration.js
+++ b/test/integration.js
@@ -11,6 +11,7 @@ testServer(handleRequest, function (request, done) {
             }
         }, function (e, r, body) {
             t.equal(body, "json")
+            t.equal(r.headers["vary"], "Accept")
 
             t.end()
         })

--- a/test/integration.js
+++ b/test/integration.js
@@ -31,7 +31,20 @@ testServer(handleRequest, function (request, done) {
 
     test("normal works", function (t) {
         request("/", function (e, r, body) {
-            t.equal(body, "normal")
+            t.equal(body, "json")
+
+            t.end()
+        })
+    })
+
+    test("default works", function (t) {
+        request({
+            uri: "/",
+            headers: {
+                accept: "foobar"
+            }
+        }, function (e, r, body) {
+            t.equal(body, "default")
 
             t.end()
         })
@@ -58,7 +71,7 @@ function handleRequest(req, res) {
     mediaTypes({
         "application/json": json,
         "text/html": html,
-        default: normal
+        default: $default
     })(req, res)
 }
 
@@ -70,6 +83,6 @@ function html(req, res) {
     res.end("html")
 }
 
-function normal(req, res) {
-    res.end("normal")
+function $default(req, res) {
+    res.end("default")
 }


### PR DESCRIPTION
Update to latest version of negotiator, which changes the default behavior for requests without an accept header present (probably merits a major version bump).

Fix setting the vary header, which was previously bugged and set the "Accept" header. I'm using the _vary_ module to do this now.
